### PR TITLE
Use the `pkgver()` function in all scripts applicable

### DIFF
--- a/packages/bashtop-git/bashtop-git.pacscript
+++ b/packages/bashtop-git/bashtop-git.pacscript
@@ -1,6 +1,5 @@
 name="bashtop-git"
 pkgname="bashtop-git"
-version="0.9.25"
 url="https://github.com/aristocratos/bashtop.git"
 build_depends=""
 depends="sed coreutils grep gawk procps python3 python3-distutils lm-sensors sysstat curl"
@@ -8,6 +7,11 @@ breaks=""
 description="Linux/OSX/FreeBSD resource monitor."
 hash="8f12a1f82a1d2971a3470d8f946d21424e3db95edf2aee71d4239841ac304bc8"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"
+pkgver() {
+    git ls-remote "${url}" master | cut -f1
+}
+version="$(pkgver)"
+
 prepare() {
     true
 }


### PR DESCRIPTION
Use the new Pacstall 1.3 "Amaranth" `pkgver()` function to fetch the upstream version.